### PR TITLE
Update persistent thrust parameters only every 16th physics tick

### DIFF
--- a/src/PersistentEngine.cs
+++ b/src/PersistentEngine.cs
@@ -43,6 +43,9 @@ namespace PersistentThrust {
 	public float ThrustPersistent = 0;
 	public float ThrottlePersistent = 0;
 
+    // Keep track of number of physics ticks skipped
+	public int skipCounter = 0;
+
 	// Are we transitioning from timewarp to reatime?
 	bool warpToReal = false;
 
@@ -58,7 +61,7 @@ namespace PersistentThrust {
 		    engine = pm as ModuleEngines;
 		    IsPersistentEngine = true;
 		} else {
-		    Debug.Log("No ModuleEngine found.");
+            Debug.Log("[PersistentThrust] No ModuleEngine found.");
 		}
 		if (pm is ModuleEnginesFX) {
 		    engineFX = pm as ModuleEnginesFX;
@@ -116,6 +119,12 @@ namespace PersistentThrust {
 	}
 
 	void UpdatePersistentParameters () {
+		// skip some ticks
+		if (skipCounter++ < 15) return;
+
+	    // we are on the 16th tick
+		skipCounter = 0;
+
 	    // Update values to use during timewarp
 	    // Get Isp
 	    IspPersistent = engine.realIsp;
@@ -154,6 +163,7 @@ namespace PersistentThrust {
 		    // For the moment, just let the full deltaV for time segment dT be applied
 		    if (demandOut == 0) {
 			depleted = true;
+            Debug.Log(String.Format("[PersistentThrust] Part {0} failed to request {1} {2}", part.name, demands[i], pp.propellant.name));
 		    }
 		}
 		// Otherwise demand is 0
@@ -215,10 +225,11 @@ namespace PersistentThrust {
 		    }
 		    // Otherwise log warning and drop out of timewarp if throttle on & depleted
 		    else if (ThrottlePersistent > 0) {
-			Debug.Log("Propellant depleted");
-			// Return to realtime
-			TimeWarp.SetRate(0, true);
-		    }
+            Debug.Log("[PersistentThrust] Thrust warp stopped - propellant depleted");
+            ScreenMessages.PostScreenMessage("Thrust warp stopped - propellant depleted", 5.0f, ScreenMessageStyle.UPPER_CENTER);
+            // Return to realtime
+            TimeWarp.SetRate(0, true);
+            }
 		}
 		// Otherwise, if suborbital, set throttle to 0 and show error message
 		// TODO fix persistent thrust orbit perturbation on suborbital trajectory


### PR DESCRIPTION
There is a problem with being unable to enter thrust warp when game physics is lagging.

It seems there are a couple of extra calls to **OnFixedUpdate()** when trying to enter on-rails warp when lagging, where the vessel is not yet packed, but thrust is set to 0. This causes the engine to request 0 propellant in the first physics tick where the vessel _is_ packed, which (although successful of course) is interpreted as the vessel being out of propellant, and the warp is interrupted.

This PR is a quick & dirty workaround to that problem, making the persistent thrust parameters update only every 16th physics tick. This makes them lag behind a bit (about 1/3 second, no big deal), which ensures thrust warp can be entered fairly consistently, although there is still the occasional unlucky activation, where the timewarp button is pressed in the wrong "phase".

There is also now an on-screen message when propellant is depleted (or not, see above), to give the player feedback.