### PR TITLE
KSPIE compatibility hotfix

### DIFF
--- a/Patches/AllEngines.cfg
+++ b/Patches/AllEngines.cfg
@@ -1,7 +1,7 @@
 // Adds PersistentEngine to any part with ModuleEnginesFX or ModuleEngines
 // Remove any other patches that add PersistentEngine
 
-@PART[*]:HAS[@MODULE[ModuleEnginesFX]]
+@PART[*]:HAS[@MODULE[ModuleEnginesFX],!MODULE[DaedalusEngineController],!MODULE[FusionEngineController],!MODULE[ElectricEngineControllerFX],!MODULE[VistaECU2]]
 {
         MODULE
         {
@@ -9,7 +9,7 @@
         }
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngines]]
+@PART[*]:HAS[@MODULE[ModuleEngines],!MODULE[DaedalusEngineController],!MODULE[FusionEngineController],!MODULE[ElectricEngineControllerFX],!MODULE[VistaECU2]]
 {
         MODULE
         {


### PR DESCRIPTION
This fix is required to make it compatible with KSP Interstellar Extended